### PR TITLE
Turn on precompilation

### DIFF
--- a/src/SMSSVD.jl
+++ b/src/SMSSVD.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 module SMSSVD
 
 
@@ -6,8 +8,9 @@ export
     projectionscore,
     projectionscorefiltered
 
-
 include("projectionscore.jl")
 include("smssvdimpl.jl")
+include("precompile.jl")
+_precompile_()
 
 end

--- a/src/SMSSVD.jl
+++ b/src/SMSSVD.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 module SMSSVD
 
 
@@ -9,5 +11,7 @@ export
 
 include("projectionscore.jl")
 include("smssvdimpl.jl")
+include("precompile.jl")
+_precompile_()
 
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,11 @@
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    precompile(Tuple{typeof(SMSSVD.α), Base.UnitRange{Int64}, Base.LinAlg.Symmetric{Float64, Array{Float64, 2}}})
+    precompile(Tuple{getfield(SMSSVD, Symbol("##projectionscorefiltered#10")), Int64, Array{Float64, 1}, typeof(identity), Array{Float64, 2}, Base.UnitRange{Int64}, Array{Float64, 1}})
+    precompile(Tuple{getfield(SMSSVD, Symbol("##smssvd#19")), Int64, Int64, typeof(identity), Array{Float64, 2}, Int64, Array{Float64, 1}})
+    precompile(Tuple{getfield(SMSSVD, Symbol("#kw##projectionscorefiltered")), Array{Any, 1}, typeof(SMSSVD.projectionscorefiltered), Array{Float64, 2}, Base.UnitRange{Int64}, Array{Float64, 1}})
+    precompile(Tuple{typeof(SMSSVD._αfiltered), Array{Float64, 2}, Base.UnitRange{Int64}, Array{Float64, 1}, Array{Float64, 1}})
+    precompile(Tuple{getfield(SMSSVD, Symbol("#kw##_svds")), Array{Any, 1}, typeof(SMSSVD._svds), Array{Float64, 2}, Array{Float64, 2}})
+    precompile(Tuple{getfield(SMSSVD, Symbol("##_svds#18")), Array{Any, 1}, typeof(identity), Array{Float64, 2}, Array{Float64, 2}})
+    precompile(Tuple{typeof(SMSSVD.smssvd), Array{Float64, 2}, Int64, Array{Float64, 1}})
+end


### PR DESCRIPTION
Most of the time taken by this function is actually compilation. This PR turns on basic precompilation (__precompile__()) and also precompiles some specific methods suggested by SnoopCompile.jl. Unfortunately, some of the compilation time corresponds to things outside this package, which can't be pre-compiled from here.  Still, this makes the first run of smssvd faster.