### PR TITLE
add convenience method to call smssvd with a length-one vector for the 'd' argument

### DIFF
--- a/.juliahistory
+++ b/.juliahistory
@@ -1,0 +1,2 @@
+using SMSSVD
+exit()

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -9,4 +9,5 @@ function _precompile_()
     precompile(Tuple{getfield(SMSSVD, Symbol("##_svds#18")), Array{Any, 1}, typeof(identity), Array{Float64, 2}, Array{Float64, 2}})
     precompile(Tuple{typeof(SMSSVD.smssvd), Array{Float64, 2}, Int64, Array{Float64, 1}})
     precompile(Tuple{typeof(SMSSVD.smssvd), Array{Float64, 2}, Int64})
+    precompile(Tuple{typeof(SMSSVD.smssvd), Array{Float64, 2}, Array{Int64, 1}})
 end

--- a/src/smssvdimpl.jl
+++ b/src/smssvdimpl.jl
@@ -26,8 +26,8 @@ Computes the SubMatrix Selection Singular Value Decomposition (SMSSVD) of a matr
 * `signalDimensions`: Vector with the number of dimensions in each signal detected by SMSSVD.
 * `selectedVariables`: For each signal, a bitmask showing the variables selected by Projection Score.
 """
-function smssvd(X, d, stdThresholds=logspace(-2,0,100); nbrIter=10, maxSignalDim=typemax(Int))
-    σMax = maximum(std(X,2)) # Always base the variable filtering on the original σ's 
+function smssvd(X, d::Integer, stdThresholds=logspace(-2,0,100); nbrIter=10, maxSignalDim=typemax(Int))
+    σMax = maximum(std(X,2)) # Always base the variable filtering on the original σ's
 
     U = zeros(size(X,1),d)
     Σ = zeros(d)
@@ -73,4 +73,8 @@ function smssvd(X, d, stdThresholds=logspace(-2,0,100); nbrIter=10, maxSignalDim
     end
 
     U,Σ,V,ps,signalDimensions,selectedVariables
+end
+
+function smssvd(X, d::Vector{T}, stdThresholds=logspace(-2,0,100); nbrIter=10, maxSignalDim=typemax(Int)) where T<:Integer
+    smssvd(X, d[1], stdThresholds, nbrIter = nbrIter, maxSignalDim = maxSignalDim)
 end


### PR DESCRIPTION
This would simplify calling smssvd from R via JuliaCall as R can't pass a scalar. We can work around this from the R side, but it would be nice to have this additional method, if you are interested.